### PR TITLE
feat: 큐 & 레디스를 활용해서 동시성 문제 해결하기

### DIFF
--- a/src/main/java/forwork/forwork_consumer/ForworkConsumerApplication.java
+++ b/src/main/java/forwork/forwork_consumer/ForworkConsumerApplication.java
@@ -3,13 +3,15 @@ package forwork.forwork_consumer;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class ForworkConsumerApplication {
 
 	public static void main(String[] args) {
 		new SpringApplicationBuilder(ForworkConsumerApplication.class)
-				.profiles("local")
+				.profiles("prod")
 				.run(args);
 	}
 }

--- a/src/main/java/forwork/forwork_consumer/api/TestController.java
+++ b/src/main/java/forwork/forwork_consumer/api/TestController.java
@@ -17,16 +17,17 @@ import java.util.List;
 public class TestController {
     private final ResumeQuantityService resumeQuantityService;
 
-    @RequestMapping(method = RequestMethod.POST, value = "/pes")
+    @RequestMapping(method = RequestMethod.POST, value = "/lettuce1")
     public ResponseEntity<String> pessimistic(
-    ){
-        resumeQuantityService.increaseSalesQuantityPessimistic(List.of(1L));
+    ) throws InterruptedException {
+        resumeQuantityService.increaseByLettuce(5L);
         return new ResponseEntity<>("confirm", HttpStatus.OK);
     }
 
-    @RequestMapping(method = RequestMethod.GET, value = "/")
-    public ResponseEntity<String> home(
-    ){
-        return new ResponseEntity<>("home", HttpStatus.OK);
+    @RequestMapping(method = RequestMethod.POST, value = "/lettuce2")
+    public ResponseEntity<String> pessimistic2(
+    ) throws InterruptedException {
+        resumeQuantityService.increaseByLettuce(6L);
+        return new ResponseEntity<>("confirm", HttpStatus.OK);
     }
 }

--- a/src/main/java/forwork/forwork_consumer/api/config/rabbitmq/RabbitMqConfig.java
+++ b/src/main/java/forwork/forwork_consumer/api/config/rabbitmq/RabbitMqConfig.java
@@ -5,7 +5,7 @@ import forwork.forwork_consumer.api.errorhandler.MyErrorHandler;
 import forwork.forwork_consumer.api.exception.MyFatalExceptionStrategy;
 import forwork.forwork_consumer.api.service.MailLogService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.amqp.core.AcknowledgeMode;
+import org.springframework.amqp.core.*;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
@@ -18,7 +18,7 @@ import org.springframework.util.ErrorHandler;
 @Configuration
 @RequiredArgsConstructor
 public class RabbitMqConfig {
-    // 커스텀 팩토리 등록
+
     private final ObjectMapper objectMapper;
     private final MailLogService mailLogService;
     private final MyFatalExceptionStrategy myFatalExceptionStrategy;
@@ -43,16 +43,6 @@ public class RabbitMqConfig {
     public ErrorHandler errorHandler() {
         return new MyErrorHandler(myFatalExceptionStrategy, objectMapper, mailLogService);
     }
-
-//    @Bean
-//    public ErrorHandler errorHandler() {
-//        return new CustomErrorHandler(fatalExceptionStrategy());
-//    }
-
-//    @Bean
-//    FatalExceptionStrategy fatalExceptionStrategy() {
-//        return new CustomFatalExceptionStrategy();
-//    }
 
     @Bean
     public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory, MessageConverter messageConverter) {

--- a/src/main/java/forwork/forwork_consumer/api/consumer/auth/AuthMailConsumer.java
+++ b/src/main/java/forwork/forwork_consumer/api/consumer/auth/AuthMailConsumer.java
@@ -41,7 +41,7 @@ public class AuthMailConsumer {
     private String issueCertificationCode(String email){
         String certificationCode = uuidHolder.random();
         String key = getKeyByEmail(email);
-        redisStringUtils.setDataWithTimeout(key, certificationCode, 300L);
+        redisStringUtils.setValueWithTimeout(key, certificationCode, 300L);
 
         return certificationCode;
     }

--- a/src/main/java/forwork/forwork_consumer/api/consumer/buyer/BuyerMailConsumer.java
+++ b/src/main/java/forwork/forwork_consumer/api/consumer/buyer/BuyerMailConsumer.java
@@ -2,6 +2,7 @@ package forwork.forwork_consumer.api.consumer.buyer;
 
 import forwork.forwork_consumer.api.consumer.buyer.message.BuyerMessage;
 import forwork.forwork_consumer.api.infrastructure.mail.MailSender;
+import forwork.forwork_consumer.api.infrastructure.redis.RedisStringUtils;
 import forwork.forwork_consumer.api.service.OrderStatusUpdateService;
 import forwork.forwork_consumer.api.validator.EmailValidator;
 import lombok.RequiredArgsConstructor;
@@ -15,16 +16,22 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @RequiredArgsConstructor
 public class BuyerMailConsumer {
-
     private static final String USER_BUYER = "user.buyer.q";
     private final MailSender mailSender;
     private final OrderStatusUpdateService orderStatusUpdateService;
+    private final RedisStringUtils redisStringUtils;
 
     @RabbitListener(queues = USER_BUYER, containerFactory = "customRabbitListenerContainerFactory")
     public void sendBuyerMail(BuyerMessage message){
         EmailValidator.validate(message);
         mailSender.send(message);
         orderStatusUpdateService.updateOrderStatusSent(message);
+        increaseResumeSalesQuantity(message);
+    }
+
+    private void increaseResumeSalesQuantity(BuyerMessage message) {
+        String key = "resume:" + message.getResumeId();
+        redisStringUtils.safeIncrement(key);
     }
 }
 

--- a/src/main/java/forwork/forwork_consumer/api/infrastructure/redis/RedisStringUtils.java
+++ b/src/main/java/forwork/forwork_consumer/api/infrastructure/redis/RedisStringUtils.java
@@ -1,21 +1,41 @@
 package forwork.forwork_consumer.api.infrastructure.redis;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class RedisStringUtils {
 
     private final RedisTemplate<String, String> redisTemplate;
 
-    public void setDataWithTimeout(String key, String value, Long ttlSeconds){
+    public Set<String> getKeys(String key){
+        return redisTemplate.keys(key);
+    }
+
+    public String getValue(String key){
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public void setValueWithTimeout(String key, String value, Long ttlSeconds){
         redisTemplate.opsForValue().set(key, value, ttlSeconds, TimeUnit.SECONDS);
     }
+
+    public void deleteKey(String key){
+        if (key == null || key.isEmpty()) {
+            return;
+        }
+        redisTemplate.delete(key);
+    }
+
     public String createKeyForm(String prefix, Object value) {
         return prefix + value;
     }
@@ -31,5 +51,43 @@ public class RedisStringUtils {
 
     private String generateKey(Long key) {
         return key.toString();
+    }
+
+
+    public void safeIncrement(String key) {
+        redisTemplate.opsForValue().increment(key, 1);
+    }
+
+    public Map<String, Integer> syncAndResetKeys(Set<String> keys) {
+        String script = """
+            local result = {}
+            for i, key in ipairs(KEYS) do
+                local current = redis.call("GET", key)
+                if current then
+                    table.insert(result, key)
+                    table.insert(result, tonumber(current))
+                    redis.call("SET", key, "0")
+                end
+            end
+            return result
+        """;
+
+        // RedisScript 선언
+        RedisScript<List> redisScript = RedisScript.of(script, List.class);
+        List<String> keyList = new ArrayList<>(keys);
+
+        // Lua 스크립트 실행
+        List<Object> result = redisTemplate.execute(redisScript, keyList);
+        Map<String, Integer> syncData = new HashMap<>();
+
+        // 결과 매핑
+        if (result != null) {
+            for (int i = 0; i < result.size(); i += 2) {
+                String key = (String) result.get(i);
+                Integer value = ((Long) result.get(i + 1)).intValue();
+                syncData.put(key, value);
+            }
+        }
+        return syncData;
     }
 }

--- a/src/main/java/forwork/forwork_consumer/api/infrastructure/resume/ResumeJpaRepository.java
+++ b/src/main/java/forwork/forwork_consumer/api/infrastructure/resume/ResumeJpaRepository.java
@@ -3,6 +3,7 @@ package forwork.forwork_consumer.api.infrastructure.resume;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -18,4 +19,8 @@ public interface ResumeJpaRepository extends JpaRepository<ResumeEntity, Long>{
     @Lock(value = LockModeType.OPTIMISTIC)
     @Query("select r from ResumeEntity r where r.id = :resumeId")
     Optional<ResumeEntity> findByIdWithOptimisticLock(@Param("resumeId") Long resumeId);
+
+    @Modifying
+    @Query("UPDATE ResumeEntity r SET r.salesQuantity = r.salesQuantity + :quantity WHERE r.id = :resumeId")
+    void updateSalesQuantity(@Param("resumeId") Long resumeId, @Param("quantity") Integer quantity);
 }

--- a/src/main/java/forwork/forwork_consumer/api/service/OrderStatusUpdateService.java
+++ b/src/main/java/forwork/forwork_consumer/api/service/OrderStatusUpdateService.java
@@ -15,7 +15,6 @@ import java.util.List;
 @RequiredArgsConstructor
 public class OrderStatusUpdateService {
 
-    private final ResumeQuantityService resumeQuantityService;
     private final OrderResumeJpaRepository orderResumeJpaRepository;
     private final ClockHolder clockHolder;
 
@@ -24,14 +23,5 @@ public class OrderStatusUpdateService {
         List<OrderResumeEntity> orderResumes = orderResumeJpaRepository
                 .findByOrderEntity_IdAndResumeEntity_Id(message.getOrderId(), message.getResumeId());
         orderResumes.forEach(orderResume -> orderResume.updateStatusSent(clockHolder));
-
-        // resumeIds 추출
-        List<Long> resumeIds = orderResumes.stream()
-                .map(OrderResumeEntity::getResumeEntity)
-                .map(ResumeEntity::getId)
-                .toList();
-
-        resumeQuantityService.increaseSalesQuantityPessimistic(resumeIds); // 판매량 1증가
-        //resumeQuantityService.increaseSalesQuantity(resumeIds); // 판매량 1증가
     }
 }

--- a/src/main/java/forwork/forwork_consumer/api/service/ResumeQuantityService.java
+++ b/src/main/java/forwork/forwork_consumer/api/service/ResumeQuantityService.java
@@ -1,15 +1,20 @@
 package forwork.forwork_consumer.api.service;
 
+import forwork.forwork_consumer.api.infrastructure.redis.RedisStringUtils;
 import forwork.forwork_consumer.api.infrastructure.resume.ResumeEntity;
 import forwork.forwork_consumer.api.infrastructure.resume.ResumeJpaRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 @Service
 @Transactional
@@ -18,11 +23,39 @@ import java.util.List;
 public class ResumeQuantityService {
 
     private final ResumeJpaRepository resumeRepository;
+    private final RedisStringUtils redisStringUtils;
 
-    public void increaseSalesQuantityPessimistic(List<Long> resumeIds){
-        for (Long resumeId : resumeIds) {
-            ResumeEntity resumeEntity = resumeRepository.findByIdWithPessimisticLock(resumeId).orElseThrow();
+    @Scheduled(fixedRate = 600000) //10분
+    public void syncRedisToDB(){
+        Set<String> keys = redisStringUtils.getKeys("resume:*");
+        if (keys == null || keys.isEmpty()) {
+            log.info("No keys found [syncRedisToDB]");
+            return;
+        }
+
+        Map<String, Integer> syncData = redisStringUtils.syncAndResetKeys(keys);
+        syncData.forEach((key, quantity) -> {
+            Long resumeId = Long.valueOf(key.split(":")[1]);
+            resumeRepository.updateSalesQuantity(resumeId, quantity);
+        });
+
+        // 불필요한 키 삭제
+        syncData.keySet().forEach(key -> {
+            if ("0".equals(redisStringUtils.getValue(key))) {
+                redisStringUtils.deleteKey(key);
+            }
+        });
+    }
+
+    public void increaseByLettuce(Long resumeId) throws InterruptedException {
+        while(!redisStringUtils.lock(resumeId)){
+            Thread.sleep(100);
+        }
+        try{
+            ResumeEntity resumeEntity = resumeRepository.findById(resumeId).orElseThrow();
             resumeEntity.increaseSalesQuantity();
+        }finally {
+            redisStringUtils.unLock(resumeId);
         }
     }
 }


### PR DESCRIPTION
- 기존에는 SELECT FOR UPDATE 를 활용 해서 판매량 업데이트
- 판매 관려 메시지를 소비할 때 레디스에 판매량 1 증가
- 배치 처리 하여 레디스에 쌓인 판매량을 1번에 쿼리로 업데이트
- Resolves: #9